### PR TITLE
Make it possible to return a React Element from getLabel again

### DIFF
--- a/src/views/DrawerNavigatorItems.js
+++ b/src/views/DrawerNavigatorItems.js
@@ -14,6 +14,7 @@ const DrawerNavigatorItems = ({
   inactiveTintColor,
   inactiveBackgroundColor,
   getLabel,
+  getAccessibilityLabel,
   renderIcon,
   onItemPress,
   itemsContainerStyle,
@@ -35,11 +36,23 @@ const DrawerNavigatorItems = ({
       const icon = renderIcon(scene);
       const label = getLabel(scene);
       const extraLabelStyle = focused ? activeLabelStyle : inactiveLabelStyle;
+      let accessibilityLabel;
+
+      if (typeof getAccessibilityLabel === 'function') {
+        accessibilityLabel = getAccessibilityLabel(scene);
+      } else if (typeof label === 'string') {
+        accessibilityLabel = label;
+      } else {
+        throw new Error(
+          "getAccessibilityLabel must be a funcion returning a string if getLabel doesn't return a string"
+        );
+      }
+
       return (
         <TouchableItem
           key={route.key}
           accessible
-          accessibilityLabel={label}
+          accessibilityLabel={accessibilityLabel}
           onPress={() => {
             onItemPress({ route, focused });
           }}

--- a/src/views/DrawerNavigatorItems.js
+++ b/src/views/DrawerNavigatorItems.js
@@ -14,6 +14,7 @@ const DrawerNavigatorItems = ({
   inactiveTintColor,
   inactiveBackgroundColor,
   getLabel,
+  getAccessibilityLabel,
   renderIcon,
   onItemPress,
   itemsContainerStyle,
@@ -33,23 +34,23 @@ const DrawerNavigatorItems = ({
         : inactiveBackgroundColor;
       const scene = { route, index, focused, tintColor: color };
       const icon = renderIcon(scene);
+      const label = getLabel(scene);
       const extraLabelStyle = focused ? activeLabelStyle : inactiveLabelStyle;
-      let label = getLabel(scene);
       let accessibilityLabel;
 
       if (typeof label === 'string') {
         accessibilityLabel = label;
-      } else if (
-        label !== null &&
-        typeof label === 'object' &&
-        typeof label.accessibilityLabel === 'string' &&
-        React.isValidElement(label.element)
-      ) {
-        label = label.element;
-        accessibilityLabel = label.accessibilityLabel;
+      } else if (typeof getAccessibilityLabel === 'function') {
+        accessibilityLabel = getAccessibilityLabel(scene);
+
+        if (typeof accessibilityLabel !== 'string') {
+          throw new Error(
+            'DrawerItems: prop getAccessibilityLabel must return a string'
+          );
+        }
       } else {
         throw new Error(
-          'DrawerItems: prop getLabel must return a string or an object containing property `accessibilityLabel` (string) and `element` (JSX.Element)'
+          'DrawerItems: prop getLabel must return a string or getAccessibilityLabel must be a function returning a string'
         );
       }
 

--- a/src/views/DrawerNavigatorItems.js
+++ b/src/views/DrawerNavigatorItems.js
@@ -14,7 +14,6 @@ const DrawerNavigatorItems = ({
   inactiveTintColor,
   inactiveBackgroundColor,
   getLabel,
-  getAccessibilityLabel,
   renderIcon,
   onItemPress,
   itemsContainerStyle,
@@ -34,17 +33,23 @@ const DrawerNavigatorItems = ({
         : inactiveBackgroundColor;
       const scene = { route, index, focused, tintColor: color };
       const icon = renderIcon(scene);
-      const label = getLabel(scene);
       const extraLabelStyle = focused ? activeLabelStyle : inactiveLabelStyle;
+      let label = getLabel(scene);
       let accessibilityLabel;
 
-      if (typeof getAccessibilityLabel === 'function') {
-        accessibilityLabel = getAccessibilityLabel(scene);
-      } else if (typeof label === 'string') {
+      if (typeof label === 'string') {
         accessibilityLabel = label;
+      } else if (
+        label !== null &&
+        typeof label === 'object' &&
+        typeof label.accessibilityLabel === 'string' &&
+        React.isValidElement(label.element)
+      ) {
+        label = label.element;
+        accessibilityLabel = label.accessibilityLabel;
       } else {
         throw new Error(
-          "getAccessibilityLabel must be a funcion returning a string if getLabel doesn't return a string"
+          'DrawerItems: prop getLabel must return a string or an object containing property `accessibilityLabel` (string) and `element` (JSX.Element)'
         );
       }
 


### PR DESCRIPTION
The commit https://github.com/react-navigation/react-navigation-drawer/commit/980e054cddb9e1ad54956c69a8fc08434b07a7c8 makes it impossible to return a Element from getLabel.

In the current version you end up with an error like
`Invariant Violation: 749,RCTView,31,[object Object] is not usable as a native method argument`

And the red screen shows the error
`Malformed calls from JS: field sizes are different.`

**This change could break code which is using `getLabel` to return a React element.**  
In the first version of this PR I introduced the additional function `getAccessibilityLabel` that wasn't as performant and you had to add more code to use it as my current version.