### PR TITLE
Added active item style for focused(active) item

### DIFF
--- a/src/views/DrawerNavigatorItems.js
+++ b/src/views/DrawerNavigatorItems.js
@@ -23,6 +23,7 @@ const DrawerNavigatorItems = ({
   inactiveLabelStyle,
   iconContainerStyle,
   drawerPosition,
+  activeItemStyle
 }) => (
   <View style={[styles.container, itemsContainerStyle]}>
     {items.map((route, index) => {
@@ -36,6 +37,7 @@ const DrawerNavigatorItems = ({
       const label = getLabel(scene);
       const accessibilityLabel = typeof label === 'string' ? label : undefined;
       const extraLabelStyle = focused ? activeLabelStyle : inactiveLabelStyle;
+      const extraItemStyle = focused ? activeItemStyle : itemStyle;
       return (
         <TouchableItem
           key={route.key}
@@ -54,7 +56,7 @@ const DrawerNavigatorItems = ({
               vertical: 'never',
             }}
           >
-            <View style={[styles.item, itemStyle]}>
+            <View style={[styles.item, extraItemStyle]}>
               {icon ? (
                 <View
                   style={[


### PR DESCRIPTION
I have added **activeItemStyle** property for currently active item(focused item). Now we can do styling on active item.

Before, we can do style for all item through itemStyle but now we cannot do style for item which is selected.

After adding **activeItemStyle** user can easily added style for active(focused) item as well for inactive item through itemStyle.

![screenshot_1549274827](https://user-images.githubusercontent.com/47051089/52201906-eabb7200-2892-11e9-8799-252fabcb1006.png)
![screenshot_1549274831](https://user-images.githubusercontent.com/47051089/52201908-eb540880-2892-11e9-952a-3d5ea24507b0.png)
![screenshot_1549274658](https://user-images.githubusercontent.com/47051089/52201925-fad35180-2892-11e9-94f4-f8aadf967b83.png)
![screenshot_1549274670](https://user-images.githubusercontent.com/47051089/52201926-fad35180-2892-11e9-8b71-2faa4ac90604.png)



