### PR TITLE
Allow touchableType

### DIFF
--- a/src/views/DrawerNavigatorItems.tsx
+++ b/src/views/DrawerNavigatorItems.tsx
@@ -6,7 +6,7 @@ import { Scene, Route } from '../types';
 
 export type Props = {
   items: Route[];
-  touchableType: 'highlight' | 'opacity';
+  touchableType?: 'opacity' | 'highlight';
   activeItemKey?: string | null;
   activeTintColor?: string;
   activeBackgroundColor?: string;
@@ -107,6 +107,7 @@ const DrawerNavigatorItems = ({
 
 /* Material design specs - https://material.io/guidelines/patterns/navigation-drawer.html#navigation-drawer-specs */
 DrawerNavigatorItems.defaultProps = {
+  touchableType: 'opacity',
   activeTintColor: '#2196f3',
   activeBackgroundColor: 'rgba(0, 0, 0, .04)',
   inactiveTintColor: 'rgba(0, 0, 0, .87)',

--- a/src/views/DrawerNavigatorItems.tsx
+++ b/src/views/DrawerNavigatorItems.tsx
@@ -6,6 +6,7 @@ import { Scene, Route } from '../types';
 
 export type Props = {
   items: Route[];
+  touchableType: 'highlight' | 'opacity';
   activeItemKey?: string | null;
   activeTintColor?: string;
   activeBackgroundColor?: string;
@@ -28,6 +29,7 @@ export type Props = {
  */
 const DrawerNavigatorItems = ({
   items,
+  touchableType,
   activeItemKey,
   activeTintColor,
   activeBackgroundColor,
@@ -59,6 +61,8 @@ const DrawerNavigatorItems = ({
       return (
         <TouchableItem
           key={route.key}
+          type={touchableType}
+          activeBackgroundColor={activeBackgroundColor}
           accessible
           accessibilityLabel={accessibilityLabel}
           onPress={() => {

--- a/src/views/TouchableItem.tsx
+++ b/src/views/TouchableItem.tsx
@@ -56,6 +56,17 @@ export default class TouchableItem extends React.Component<Props> {
         </TouchableNativeFeedback>
       );
     }
+                                  
+     if(this.props.type === 'highlight') {
+      return (
+				<TouchableHighlight
+					{...this.props}
+					underlayColor={this.props.activeBackgroundColor}
+				>
+					{this.props.children}
+				</TouchableHighlight>
+			);
+    }
 
     return (
       <TouchableOpacity {...this.props}>{this.props.children}</TouchableOpacity>

--- a/src/views/TouchableItem.tsx
+++ b/src/views/TouchableItem.tsx
@@ -10,9 +10,10 @@
 import * as React from 'react';
 import {
   Platform,
+  View,
   TouchableNativeFeedback,
   TouchableOpacity,
-  View,
+  TouchableHighlight,
   TouchableWithoutFeedback,
 } from 'react-native';
 


### PR DESCRIPTION
Why not allow touchableType to enable a Slack-like drawer? Can default to 'opacity'