### PR TITLE
Fix "DrawerActions" typo

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,13 +4,13 @@
 /**
  * Router
  */
-import * as DrawerAcions from './routers/DrawerActions';
+import * as DrawerActions from './routers/DrawerActions';
 
 export {
   default as createDrawerNavigator,
 } from './navigators/createDrawerNavigator';
 
-export { DrawerAcions };
+export { DrawerActions };
 export { default as DrawerRouter } from './routers/DrawerRouter';
 
 /**


### PR DESCRIPTION
Browsing the source code and noticed a typo in the main exports– didn't see an issue or PR related to it so figured I'd throw one up here.

Technically it's probably a "breaking change" since it's changing a named export from `DrawerAcions` to `DrawerActions`.