### PR TITLE
fix: immediate closing drawer on fully opened

### DIFF
--- a/src/views/Drawer.tsx
+++ b/src/views/Drawer.tsx
@@ -251,6 +251,7 @@ export default class DrawerView extends React.PureComponent<Props> {
       position: this.position,
       time: new Value(0),
       finished: new Value(FALSE),
+      velocity: new Value(0),
     };
 
     return block([
@@ -261,14 +262,11 @@ export default class DrawerView extends React.PureComponent<Props> {
         set(frameTime, 0),
         set(state.time, 0),
         set(state.finished, FALSE),
+        set(state.velocity, this.velocityX),
         set(this.isOpen, isOpen),
         startClock(this.clock),
       ]),
-      spring(
-        this.clock,
-        { ...state, velocity: this.velocityX },
-        { ...SPRING_CONFIG, toValue }
-      ),
+      spring(this.clock, state, { ...SPRING_CONFIG, toValue }),
       cond(state.finished, [
         // Reset gesture and velocity from previous gesture
         set(this.touchX, 0),


### PR DESCRIPTION
## Motivation 
There was an issue when drawer has been fully opened by gesture and then finger released. The drawer was immediately closed which was definitely not expected behavior. 
Video: 
https://streamable.com/mnkpv

Having observed how values are being changes I have noticed that the problem is related to a `this.velocityX` value.
This value has been used as a source of the true for calculating if drawer should be opened or not. It was not a good solution, because this was not only representing the current velocity of gesture but also the velocity of an animation. In this situation triggered animation led to overriding velocity's value to another one which led to a recalculation of `this.isOpen` and then to closing a drawer.

## Changes
Fix is very simple. In order not to override velocity by a `spring` animation I made a copy of this value and set it with current velocity on the begging of an animation.   