### PR TITLE
fix: spring was not triggered sometimes on tap

### DIFF
--- a/src/views/Drawer.tsx
+++ b/src/views/Drawer.tsx
@@ -243,7 +243,7 @@ export default class DrawerView extends React.PureComponent<Props> {
 
   private isStatusBarHidden: boolean = false;
 
-  private isSpringManuallyTriggered = new Value<number>(FALSE);
+  private isSpringManuallyTriggered = new Value<Binary>(FALSE);
 
   private transitionTo = (isOpen: number | Animated.Node<number>) => {
     const toValue = new Value(0);

--- a/src/views/Drawer.tsx
+++ b/src/views/Drawer.tsx
@@ -349,6 +349,7 @@ export default class DrawerView extends React.PureComponent<Props> {
     cond(
       eq(this.gestureState, State.ACTIVE),
       [
+        set(this.isSpringManuallyTriggered, FALSE),
         cond(this.isSwiping, NOOP, [
           // We weren't dragging before, set it to true
           set(this.isSwiping, TRUE),
@@ -397,7 +398,6 @@ export default class DrawerView extends React.PureComponent<Props> {
         ),
       ]
     ),
-    set(this.isSpringManuallyTriggered, FALSE),
     this.position,
   ]);
 


### PR DESCRIPTION
## Motivation
Sometimes tap on overlay appeared not to trigger action.
The reason was that node passed to `this.transitionTo` was not refreshing because `cond` was evaluating to `true` and didn't respect changes of `this.isOpen`

## Changes
I've added a special flag for "manual" setting switch could be reverted on enabling Pan Handler

