### PR TITLE
Reset this.gestureX on manual setting

### DIFF
--- a/src/views/Drawer.tsx
+++ b/src/views/Drawer.tsx
@@ -329,6 +329,7 @@ export default class DrawerView extends React.PureComponent<Props> {
         cond(clockRunning(this.clock), stopClock(this.clock)),
         // Update the open value to trigger the transition
         set(this.isOpen, this.nextIsOpen),
+        set(this.gestureX, 0),
         set(this.nextIsOpen, UNSET),
       ])
     ),


### PR DESCRIPTION
## Motivation
On very fast close drawer and then clicking "open drawer" no action happened
The reason was that value was badly calculated bc it has considered not position and velocity of prev gesture.
## Changes
On changing the value manually I reset `gestureX`. It led to not passing condition in node passed to `this.transitionTo`