### PR TITLE
Move `react-native-screens` from peer to optionalDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,9 @@
     "react": "*",
     "react-native": "*",
     "react-native-gesture-handler": "^1.0.12",
-    "react-native-reanimated": "^1.0.0",
+    "react-native-reanimated": "^1.0.0"
+  },
+  "optionalDependencies": {
     "react-native-screens": "^1.0.0 || ^1.0.0-alpha"
   },
   "jest": {


### PR DESCRIPTION
Fixes https://github.com/react-navigation/drawer/issues/80