### PR TITLE
fix: Introduce aliases for the unsafe lifecycles

### DIFF
--- a/src/views/Drawer.tsx
+++ b/src/views/Drawer.tsx
@@ -105,7 +105,7 @@ export default class DrawerView extends React.PureComponent<Props> {
     statusBarAnimation: 'slide',
   };
 
-  componentDidUpdate(prevProps: Props) {
+  UNSAFE_componentDidUpdate(prevProps: Props) {
     const {
       open,
       drawerPosition,
@@ -157,7 +157,7 @@ export default class DrawerView extends React.PureComponent<Props> {
     }
   }
 
-  componentWillUnmount() {
+  UNSAFE_componentWillUnmount() {
     this.toggleStatusBar(false);
   }
 

--- a/src/views/DrawerView.tsx
+++ b/src/views/DrawerView.tsx
@@ -80,11 +80,11 @@ export default class DrawerView extends React.PureComponent<Props, State> {
         : this.props.navigationConfig.drawerWidth,
   };
 
-  componentDidMount() {
+  UNSAFE_componentDidMount() {
     Dimensions.addEventListener('change', this.updateWidth);
   }
 
-  componentWillUnmount() {
+  UNSAFE_componentWillUnmount() {
     Dimensions.removeEventListener('change', this.updateWidth);
   }
 


### PR DESCRIPTION
Adds UNSAFE_ prefix for deprecated lifecycle hooks. (For more information about this codemod, see [React RFC #6](https://github.com/reactjs/rfcs/pull/6))

