### PR TITLE
Support Ripple Color Property under ItemStyles

### DIFF
--- a/src/views/DrawerNavigatorItems.tsx
+++ b/src/views/DrawerNavigatorItems.tsx
@@ -58,6 +58,7 @@ const DrawerNavigatorItems = ({
       const extraLabelStyle = focused ? activeLabelStyle : inactiveLabelStyle;
       return (
         <TouchableItem
+          rippleColor={itemStyle.rippleColor}
           key={route.key}
           accessible
           accessibilityLabel={accessibilityLabel}

--- a/src/views/TouchableItem.tsx
+++ b/src/views/TouchableItem.tsx
@@ -48,7 +48,7 @@ export default class TouchableItem extends React.Component<Props> {
           {...rest}
           style={null}
           background={TouchableNativeFeedback.Ripple(
-            		this.props.rippleColor ? this.props.rippleColor: this.props.pressColor,
+            this.props.rippleColor ? this.props.rippleColor: this.props.pressColor,
             this.props.borderless
           )}
         >

--- a/src/views/TouchableItem.tsx
+++ b/src/views/TouchableItem.tsx
@@ -48,7 +48,7 @@ export default class TouchableItem extends React.Component<Props> {
           {...rest}
           style={null}
           background={TouchableNativeFeedback.Ripple(
-            this.props.pressColor,
+            		this.props.rippleColor ? this.props.rippleColor: this.props.pressColor,
             this.props.borderless
           )}
         >

--- a/src/views/TouchableItem.tsx
+++ b/src/views/TouchableItem.tsx
@@ -21,6 +21,7 @@ const ANDROID_VERSION_LOLLIPOP = 21;
 type Props = React.ComponentProps<typeof TouchableWithoutFeedback> & {
   pressColor: string;
   borderless: boolean;
+  rippleColor: string;
 };
 
 export default class TouchableItem extends React.Component<Props> {


### PR DESCRIPTION
Hey! I've been looking in the docs to find anyreference to change the ripple color but couldn't find anything.

2 lines added to support this property -- I'm already using this in my Android App project so I thought maybe there are some other guys who might be interested in using this option.

Usage:
![image](https://user-images.githubusercontent.com/37621213/64068813-e6074280-cc56-11e9-973e-581b605e4918.png)
