### PR TITLE
Fixing drawer lock mode not working properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "typescript": "tsc --noEmit",
     "example": "yarn --cwd example",
     "bootstrap": "yarn example && yarn",
-    "prepare": "bob build",
+    "prepare": "echo 'skip prepare'",
     "release": "release-it"
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "typescript": "tsc --noEmit",
     "example": "yarn --cwd example",
     "bootstrap": "yarn example && yarn",
-    "prepare": "echo 'skip prepare'",
+    "prepare": "bob build",
     "release": "release-it"
   },
   "publishConfig": {

--- a/src/views/DrawerView.tsx
+++ b/src/views/DrawerView.tsx
@@ -234,7 +234,7 @@ export default class DrawerView extends React.PureComponent<Props, State> {
       gestureHandlerProps,
     } = this.props.navigationConfig;
     const activeKey = navigation.state.routes[navigation.state.index].key;
-    const drawerLockMode = this.props.descriptors[activeKey].options || this.props.navigationConfig.drawerLockMode;
+    const drawerLockMode = this.props.descriptors[activeKey].options.drawerLockMode || this.props.navigationConfig.drawerLockMode;
 
     const drawerBackgroundColor = this.getDrawerBackgroundColor();
     const overlayColor = this.getOverlayColor();

--- a/src/views/DrawerView.tsx
+++ b/src/views/DrawerView.tsx
@@ -234,7 +234,7 @@ export default class DrawerView extends React.PureComponent<Props, State> {
       gestureHandlerProps,
     } = this.props.navigationConfig;
     const activeKey = navigation.state.routes[navigation.state.index].key;
-    const { drawerLockMode } = this.props.descriptors[activeKey].options;
+    const drawerLockMode = this.props.descriptors[activeKey].options || this.props.navigationConfig.drawerLockMode;
 
     const drawerBackgroundColor = this.getDrawerBackgroundColor();
     const overlayColor = this.getOverlayColor();


### PR DESCRIPTION
I was testing the latest drawer package and noticed that drawerLockMode is not actually pulled in correctly.

I assume you guys want flexibility to specify it per scene, but there has to be a global override and default value for it.

This pull request fixes it.