### PR TITLE
Fix type of the `navigation` field in DrawerContentComponentProps

### DIFF
--- a/src/types.tsx
+++ b/src/types.tsx
@@ -99,7 +99,7 @@ export type DrawerNavigatorItemsProps = {
 };
 
 export type DrawerContentComponentProps = DrawerNavigatorItemsProps & {
-  navigation: NavigationProp<NavigationDrawerState>;
+  navigation: NavigationScreenProp<NavigationDrawerState>;
   descriptors: SceneDescriptorMap;
   drawerOpenProgress: Animated.Node<number>;
   screenProps: unknown;

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -3,7 +3,6 @@ import {
   NavigationState,
   NavigationRoute,
   NavigationParams,
-  NavigationProp,
   NavigationDescriptor,
   SupportedThemes,
   NavigationScreenConfig,

--- a/src/views/DrawerSidebar.tsx
+++ b/src/views/DrawerSidebar.tsx
@@ -3,8 +3,8 @@ import { StyleSheet, View, ViewStyle } from 'react-native';
 import {
   NavigationActions,
   NavigationRoute,
-  NavigationScreenProp
-} from "react-navigation";
+  NavigationScreenProp,
+} from 'react-navigation';
 import Animated from 'react-native-reanimated';
 import {
   Scene,

--- a/src/views/DrawerSidebar.tsx
+++ b/src/views/DrawerSidebar.tsx
@@ -3,8 +3,8 @@ import { StyleSheet, View, ViewStyle } from 'react-native';
 import {
   NavigationActions,
   NavigationRoute,
-  NavigationProp,
-} from 'react-navigation';
+  NavigationScreenProp
+} from "react-navigation";
 import Animated from 'react-native-reanimated';
 import {
   Scene,
@@ -17,7 +17,7 @@ type Props = {
   contentComponent?: React.ComponentType<DrawerContentComponentProps>;
   contentOptions?: object;
   screenProps?: unknown;
-  navigation: NavigationProp<NavigationDrawerState>;
+  navigation: NavigationScreenProp<NavigationDrawerState>;
   descriptors: SceneDescriptorMap;
   drawerOpenProgress: Animated.Node<number>;
   drawerPosition: 'left' | 'right';
@@ -73,7 +73,6 @@ class DrawerSidebar extends React.PureComponent<Props> {
     focused: boolean;
   }) => {
     if (focused) {
-      // @ts-ignore
       this.props.navigation.closeDrawer();
     } else {
       this.props.navigation.dispatch(

--- a/src/views/DrawerView.tsx
+++ b/src/views/DrawerView.tsx
@@ -4,8 +4,8 @@ import {
   SceneView,
   ThemeColors,
   ThemeContext,
-  NavigationProp,
-} from 'react-navigation';
+  NavigationScreenProp
+} from "react-navigation";
 import { ScreenContainer } from 'react-native-screens';
 
 import * as DrawerActions from '../routers/DrawerActions';
@@ -41,7 +41,7 @@ type DrawerOptions = {
 
 type Props = {
   lazy: boolean;
-  navigation: NavigationProp<NavigationDrawerState>;
+  navigation: NavigationScreenProp<NavigationDrawerState>;
   descriptors: SceneDescriptorMap;
   navigationConfig: DrawerOptions & {
     contentComponent?: React.ComponentType<DrawerContentComponentProps>;

--- a/src/views/DrawerView.tsx
+++ b/src/views/DrawerView.tsx
@@ -4,8 +4,8 @@ import {
   SceneView,
   ThemeColors,
   ThemeContext,
-  NavigationScreenProp
-} from "react-navigation";
+  NavigationScreenProp,
+} from 'react-navigation';
 import { ScreenContainer } from 'react-native-screens';
 
 import * as DrawerActions from '../routers/DrawerActions';


### PR DESCRIPTION
Closes #103

The commit in which DrawerItemsProps was removed is here: https://github.com/react-navigation/react-navigation/commit/9bdf5fa78483fa8906ed89b025a93e63b06df4f2#diff-4c9ef844fb7fba25c52a2ad6cb776b75

I believe that `NavigationDrawerState` has been correctly migrated over from `DrawerNavigationState`; `DrawerNavigationState` originally consisted of `isTransitioning` and `isDrawerOpen`, `isTransitioning` has found its way into `NavigationState` which is part of the `NavigationDrawerState` intersection type.

https://github.com/react-navigation/react-navigation/blob/edc4ace20009b991f67103b19c2d769744f48a05/typescript/react-navigation.d.ts#L130

I found a related issue: the `navigation` prop of `DrawerSideBar.tsx` and `DrawerView.tsx` are also missing various methods such as `openDrawer()` and `closeDrawer()` because they are of type `NavigationProp`. https://github.com/react-navigation/drawer/blob/8d09a811bdf1386465df0777051ca38afa2f99ed/src/views/DrawerSidebar.tsx#L75-L78
~~Perhaps it is better to create a new issue for those.~~ EDIT: They must be fixed together because both are used internally within `createDrawerNavigator.tsx` and the navigation prop is passed in.