### PR TITLE
feat(drawer): expose draweropenprogress via react-contextapi

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,6 +21,9 @@ export { default as DrawerSidebar } from './views/DrawerSidebar';
 export { default as DrawerView } from './views/DrawerView';
 
 export { default as DrawerGestureContext } from './utils/DrawerGestureContext';
+export {
+  default as DrawerProgressContext,
+} from './utils/DrawerProgressContext';
 
 /**
  * Types

--- a/src/utils/DrawerProgressContext.tsx
+++ b/src/utils/DrawerProgressContext.tsx
@@ -1,0 +1,4 @@
+import * as React from 'react';
+import Animated from 'react-native-reanimated';
+
+export default React.createContext<Animated.Node<number> | null>(null);

--- a/src/views/Drawer.tsx
+++ b/src/views/Drawer.tsx
@@ -514,86 +514,84 @@ export default class DrawerView extends React.PureComponent<Props> {
       : { left: 0, width: open ? undefined : swipeEdgeWidth };
 
     return (
-      <DrawerProgressContext.Provider value={this.progress}>
-        <PanGestureHandler
-          ref={onGestureRef}
-          activeOffsetX={[-SWIPE_DISTANCE_MINIMUM, SWIPE_DISTANCE_MINIMUM]}
-          failOffsetY={[-SWIPE_DISTANCE_MINIMUM, SWIPE_DISTANCE_MINIMUM]}
-          onGestureEvent={this.handleGestureEvent}
-          onHandlerStateChange={this.handleGestureEvent}
-          hitSlop={hitSlop}
-          enabled={!locked}
-          {...gestureHandlerProps}
+      <PanGestureHandler
+        ref={onGestureRef}
+        activeOffsetX={[-SWIPE_DISTANCE_MINIMUM, SWIPE_DISTANCE_MINIMUM]}
+        failOffsetY={[-SWIPE_DISTANCE_MINIMUM, SWIPE_DISTANCE_MINIMUM]}
+        onGestureEvent={this.handleGestureEvent}
+        onHandlerStateChange={this.handleGestureEvent}
+        hitSlop={hitSlop}
+        enabled={!locked}
+        {...gestureHandlerProps}
+      >
+        <Animated.View
+          onLayout={this.handleContainerLayout}
+          style={styles.main}
         >
           <Animated.View
-            onLayout={this.handleContainerLayout}
-            style={styles.main}
+            style={[
+              styles.content,
+              {
+                transform: [{ translateX: contentTranslateX }],
+              },
+              sceneContainerStyle as any,
+            ]}
           >
-            <Animated.View
-              style={[
-                styles.content,
-                {
-                  transform: [{ translateX: contentTranslateX }],
-                },
-                sceneContainerStyle as any,
-              ]}
-            >
-              {renderSceneContent({ progress: this.progress })}
-              <TapGestureHandler
-                onHandlerStateChange={this.handleTapStateChange}
-              >
-                <Animated.View
-                  style={[
-                    styles.overlay,
-                    {
-                      opacity: interpolate(this.progress, {
-                        inputRange: [PROGRESS_EPSILON, 1],
-                        outputRange: [0, 1],
-                      }),
-                      // We don't want the user to be able to press through the overlay when drawer is open
-                      // One approach is to adjust the pointerEvents based on the progress
-                      // But we can also send the overlay behind the screen, which works, and is much less code
-                      zIndex: cond(
-                        greaterThan(this.progress, PROGRESS_EPSILON),
-                        0,
-                        -1
-                      ),
-                    },
-                    overlayStyle,
-                  ]}
-                />
-              </TapGestureHandler>
-            </Animated.View>
-            <Animated.Code
-              exec={block([
-                onChange(this.manuallyTriggerSpring, [
-                  cond(eq(this.manuallyTriggerSpring, TRUE), [
-                    set(this.nextIsOpen, FALSE),
-                    call([], () => (this.currentOpenValue = false)),
-                  ]),
-                ]),
-              ])}
-            />
-            <Animated.View
-              accessibilityViewIsModal={open}
-              removeClippedSubviews={Platform.OS !== 'ios'}
-              onLayout={this.handleDrawerLayout}
-              style={[
-                styles.container,
-                right ? { right: offset } : { left: offset },
-                {
-                  transform: [{ translateX: drawerTranslateX }],
-                  opacity: this.drawerOpacity,
-                  zIndex: drawerType === 'back' ? -1 : 0,
-                },
-                drawerStyle as any,
-              ]}
-            >
-              {renderDrawerContent({ progress: this.progress })}
-            </Animated.View>
+            {renderSceneContent({ progress: this.progress })}
+            <TapGestureHandler onHandlerStateChange={this.handleTapStateChange}>
+              <Animated.View
+                style={[
+                  styles.overlay,
+                  {
+                    opacity: interpolate(this.progress, {
+                      inputRange: [PROGRESS_EPSILON, 1],
+                      outputRange: [0, 1],
+                    }),
+                    // We don't want the user to be able to press through the overlay when drawer is open
+                    // One approach is to adjust the pointerEvents based on the progress
+                    // But we can also send the overlay behind the screen, which works, and is much less code
+                    zIndex: cond(
+                      greaterThan(this.progress, PROGRESS_EPSILON),
+                      0,
+                      -1
+                    ),
+                  },
+                  overlayStyle,
+                ]}
+              />
+            </TapGestureHandler>
           </Animated.View>
-        </PanGestureHandler>
-      </DrawerProgressContext.Provider>
+          <Animated.Code
+            exec={block([
+              onChange(this.manuallyTriggerSpring, [
+                cond(eq(this.manuallyTriggerSpring, TRUE), [
+                  set(this.nextIsOpen, FALSE),
+                  call([], () => (this.currentOpenValue = false)),
+                ]),
+              ]),
+            ])}
+          />
+          <Animated.View
+            accessibilityViewIsModal={open}
+            removeClippedSubviews={Platform.OS !== 'ios'}
+            onLayout={this.handleDrawerLayout}
+            style={[
+              styles.container,
+              right ? { right: offset } : { left: offset },
+              {
+                transform: [{ translateX: drawerTranslateX }],
+                opacity: this.drawerOpacity,
+                zIndex: drawerType === 'back' ? -1 : 0,
+              },
+              drawerStyle as any,
+            ]}
+          >
+            <DrawerProgressContext.Provider value={this.progress}>
+              {renderDrawerContent({ progress: this.progress })}
+            </DrawerProgressContext.Provider>
+          </Animated.View>
+        </Animated.View>
+      </PanGestureHandler>
     );
   }
 }

--- a/src/views/Drawer.tsx
+++ b/src/views/Drawer.tsx
@@ -514,83 +514,85 @@ export default class DrawerView extends React.PureComponent<Props> {
       : { left: 0, width: open ? undefined : swipeEdgeWidth };
 
     return (
-      <DrawerProgressContext.Provider value={this.progress} >
-      <PanGestureHandler
-        ref={onGestureRef}
-        activeOffsetX={[-SWIPE_DISTANCE_MINIMUM, SWIPE_DISTANCE_MINIMUM]}
-        failOffsetY={[-SWIPE_DISTANCE_MINIMUM, SWIPE_DISTANCE_MINIMUM]}
-        onGestureEvent={this.handleGestureEvent}
-        onHandlerStateChange={this.handleGestureEvent}
-        hitSlop={hitSlop}
-        enabled={!locked}
-        {...gestureHandlerProps}
-      >
-        <Animated.View
-          onLayout={this.handleContainerLayout}
-          style={styles.main}
+      <DrawerProgressContext.Provider value={this.progress}>
+        <PanGestureHandler
+          ref={onGestureRef}
+          activeOffsetX={[-SWIPE_DISTANCE_MINIMUM, SWIPE_DISTANCE_MINIMUM]}
+          failOffsetY={[-SWIPE_DISTANCE_MINIMUM, SWIPE_DISTANCE_MINIMUM]}
+          onGestureEvent={this.handleGestureEvent}
+          onHandlerStateChange={this.handleGestureEvent}
+          hitSlop={hitSlop}
+          enabled={!locked}
+          {...gestureHandlerProps}
         >
           <Animated.View
-            style={[
-              styles.content,
-              {
-                transform: [{ translateX: contentTranslateX }],
-              },
-              sceneContainerStyle as any,
-            ]}
+            onLayout={this.handleContainerLayout}
+            style={styles.main}
           >
-            {renderSceneContent({ progress: this.progress })}
-            <TapGestureHandler onHandlerStateChange={this.handleTapStateChange}>
-              <Animated.View
-                style={[
-                  styles.overlay,
-                  {
-                    opacity: interpolate(this.progress, {
-                      inputRange: [PROGRESS_EPSILON, 1],
-                      outputRange: [0, 1],
-                    }),
-                    // We don't want the user to be able to press through the overlay when drawer is open
-                    // One approach is to adjust the pointerEvents based on the progress
-                    // But we can also send the overlay behind the screen, which works, and is much less code
-                    zIndex: cond(
-                      greaterThan(this.progress, PROGRESS_EPSILON),
-                      0,
-                      -1
-                    ),
-                  },
-                  overlayStyle,
-                ]}
-              />
-            </TapGestureHandler>
-          </Animated.View>
-          <Animated.Code
-            exec={block([
-              onChange(this.manuallyTriggerSpring, [
-                cond(eq(this.manuallyTriggerSpring, TRUE), [
-                  set(this.nextIsOpen, FALSE),
-                  call([], () => (this.currentOpenValue = false)),
+            <Animated.View
+              style={[
+                styles.content,
+                {
+                  transform: [{ translateX: contentTranslateX }],
+                },
+                sceneContainerStyle as any,
+              ]}
+            >
+              {renderSceneContent({ progress: this.progress })}
+              <TapGestureHandler
+                onHandlerStateChange={this.handleTapStateChange}
+              >
+                <Animated.View
+                  style={[
+                    styles.overlay,
+                    {
+                      opacity: interpolate(this.progress, {
+                        inputRange: [PROGRESS_EPSILON, 1],
+                        outputRange: [0, 1],
+                      }),
+                      // We don't want the user to be able to press through the overlay when drawer is open
+                      // One approach is to adjust the pointerEvents based on the progress
+                      // But we can also send the overlay behind the screen, which works, and is much less code
+                      zIndex: cond(
+                        greaterThan(this.progress, PROGRESS_EPSILON),
+                        0,
+                        -1
+                      ),
+                    },
+                    overlayStyle,
+                  ]}
+                />
+              </TapGestureHandler>
+            </Animated.View>
+            <Animated.Code
+              exec={block([
+                onChange(this.manuallyTriggerSpring, [
+                  cond(eq(this.manuallyTriggerSpring, TRUE), [
+                    set(this.nextIsOpen, FALSE),
+                    call([], () => (this.currentOpenValue = false)),
+                  ]),
                 ]),
-              ]),
-            ])}
-          />
-          <Animated.View
-            accessibilityViewIsModal={open}
-            removeClippedSubviews={Platform.OS !== 'ios'}
-            onLayout={this.handleDrawerLayout}
-            style={[
-              styles.container,
-              right ? { right: offset } : { left: offset },
-              {
-                transform: [{ translateX: drawerTranslateX }],
-                opacity: this.drawerOpacity,
-                zIndex: drawerType === 'back' ? -1 : 0,
-              },
-              drawerStyle as any,
-            ]}
-          >
-            {renderDrawerContent({ progress: this.progress })}
+              ])}
+            />
+            <Animated.View
+              accessibilityViewIsModal={open}
+              removeClippedSubviews={Platform.OS !== 'ios'}
+              onLayout={this.handleDrawerLayout}
+              style={[
+                styles.container,
+                right ? { right: offset } : { left: offset },
+                {
+                  transform: [{ translateX: drawerTranslateX }],
+                  opacity: this.drawerOpacity,
+                  zIndex: drawerType === 'back' ? -1 : 0,
+                },
+                drawerStyle as any,
+              ]}
+            >
+              {renderDrawerContent({ progress: this.progress })}
+            </Animated.View>
           </Animated.View>
-        </Animated.View>
-      </PanGestureHandler>
+        </PanGestureHandler>
       </DrawerProgressContext.Provider>
     );
   }

--- a/src/views/Drawer.tsx
+++ b/src/views/Drawer.tsx
@@ -14,6 +14,7 @@ import {
   State,
 } from 'react-native-gesture-handler';
 import Animated from 'react-native-reanimated';
+import DrawerProgressContext from '../utils/DrawerProgressContext';
 
 const {
   Clock,
@@ -513,6 +514,7 @@ export default class DrawerView extends React.PureComponent<Props> {
       : { left: 0, width: open ? undefined : swipeEdgeWidth };
 
     return (
+      <DrawerProgressContext.Provider value={this.progress} >
       <PanGestureHandler
         ref={onGestureRef}
         activeOffsetX={[-SWIPE_DISTANCE_MINIMUM, SWIPE_DISTANCE_MINIMUM]}
@@ -589,6 +591,7 @@ export default class DrawerView extends React.PureComponent<Props> {
           </Animated.View>
         </Animated.View>
       </PanGestureHandler>
+      </DrawerProgressContext.Provider>
     );
   }
 }


### PR DESCRIPTION
pr for #64 

added a new context `DrawerProgressContext` which takes the progress value from `drawer.tsx` so that it can be used directly via `DrawerProgressContext.Consumer` in the screen